### PR TITLE
Support replace-platform flag when handling single Mach-O file

### DIFF
--- a/src/parse_macho_for_main.c
+++ b/src/parse_macho_for_main.c
@@ -243,6 +243,8 @@ parse_macho_file_for_main(const struct parse_macho_for_main_args args) {
         return E_PARSE_MACHO_FOR_MAIN_OTHER_ERROR;
     }
 
+    tbd_for_main_handle_post_parse(args.tbd);
+
     if (args.options.verify_write_path) {
         verify_write_path(args.tbd);
     }


### PR DESCRIPTION
On base branch:

```
$ bin/tbd -p --replace-platform ios --replace-archs armv7 armv7s arm64 -v v3 /usr/lib/ssh-keychain.dylib | head
--- !tapi-tbd-v3
archs:                 [ armv7, armv7s, arm64 ]
platform:              (null)
flags:                 [ flat_namespace ]
install-name:          "/usr/lib/ssh-keychain.dylib"
current-version:       1
compatibility-version: 1
objc-constraint:       retain_release
exports:
  - archs:                [ armv7, armv7s, arm64 ]
```

Note that `platform` is `null`, even though we passed `--replace-platform ios`

With PR:

```

$ bin/tbd -p --replace-platform ios --replace-archs armv7 armv7s arm64 -v v3 /usr/lib/ssh-keychain.dylib | head
--- !tapi-tbd-v3
archs:                 [ armv7, armv7s, arm64 ]
platform:              ios
flags:                 [ flat_namespace ]
install-name:          "/usr/lib/ssh-keychain.dylib"
current-version:       1
compatibility-version: 1
objc-constraint:       retain_release
exports:
  - archs:                [ armv7, armv7s, arm64 ]
```