### PR TITLE
Use the platform of the source Mach-O file unless ignore_platform

### DIFF
--- a/src/macho_file_parse_load_commands.c
+++ b/src/macho_file_parse_load_commands.c
@@ -387,7 +387,7 @@ handle_targets_platform_and_uuid(
         if (handle_uuid_result != E_MACHO_FILE_PARSE_OK) {
             return handle_uuid_result;
         }
-    } else if (arch != NULL) {
+    } else if (!tbd_options.ignore_platform) {
         if (platform == TBD_PLATFORM_NONE) {
             const bool should_continue =
                 call_callback(callback,


### PR DESCRIPTION
On base branch:

```
$ bin/tbd -p --replace-archs armv7 armv7s arm64 -v v3 /usr/lib/ssh-keychain.dylib | head
--- !tapi-tbd-v3
archs:                 [ armv7, armv7s, arm64 ]
platform:              (null)
flags:                 [ flat_namespace ]
install-name:          "/usr/lib/ssh-keychain.dylib"
current-version:       1
compatibility-version: 1
objc-constraint:       retain_release
exports:
  - archs:                [ armv7, armv7s, arm64 ]
```

Note that `platform` is `null`.

With PR:

```
$ bin/tbd -p --replace-archs armv7 armv7s arm64 -v v3 /usr/lib/ssh-keychain.dylib | head
--- !tapi-tbd-v3
archs:                 [ armv7, armv7s, arm64 ]
platform:              macosx
flags:                 [ flat_namespace ]
install-name:          "/usr/lib/ssh-keychain.dylib"
current-version:       1
compatibility-version: 1
objc-constraint:       retain_release
exports:
  - archs:                [ armv7, armv7s, arm64 ]
```

----

I think that the tbd platform should be selected from the source Mach-O in all cases except if `ignore_platform` is it. `ignore_targets` implies `ignore_platform`. 
In the `handle_targets_platform_and_uuid` function that this PR changes, `ignore_targets` is checked first, so I believe both of these cases are handled.